### PR TITLE
Switch to Maven build tooling

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,24 @@
+name: Build and Test
+
+on:
+  push:
+    branches: [ main ]
+  pull_request:
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout source
+        uses: actions/checkout@v4
+
+      - name: Set up Java
+        uses: actions/setup-java@v4
+        with:
+          distribution: temurin
+          java-version: '21'
+          cache: 'maven'
+
+      - name: Build with Maven
+        run: mvn -B verify

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,10 @@
+# Maven
+/target/
+
+# IDEs
+.idea/
+*.iml
+.vscode/
+
+# OS
+.DS_Store

--- a/README.md
+++ b/README.md
@@ -1,2 +1,11 @@
 # workplan
+
 Jira-liked application for agile workflow management
+
+## Development
+
+1. Ensure Java 21 and Maven 3.9+ are available on your machine.
+2. Run the build and tests:
+   ```bash
+   mvn verify
+   ```

--- a/pom.xml
+++ b/pom.xml
@@ -1,0 +1,44 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <groupId>org.springframework.boot</groupId>
+        <artifactId>spring-boot-starter-parent</artifactId>
+        <version>3.3.4</version>
+        <relativePath/>
+    </parent>
+
+    <groupId>com.example</groupId>
+    <artifactId>workplan</artifactId>
+    <version>0.0.1-SNAPSHOT</version>
+    <name>workplan</name>
+    <description>Workplan Spring Boot application</description>
+
+    <properties>
+        <java.version>21</java.version>
+    </properties>
+
+    <dependencies>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-test</artifactId>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.springframework.boot</groupId>
+                <artifactId>spring-boot-maven-plugin</artifactId>
+            </plugin>
+        </plugins>
+    </build>
+</project>

--- a/src/main/java/com/example/workplan/WorkplanApplication.java
+++ b/src/main/java/com/example/workplan/WorkplanApplication.java
@@ -1,0 +1,12 @@
+package com.example.workplan;
+
+import org.springframework.boot.SpringApplication;
+import org.springframework.boot.autoconfigure.SpringBootApplication;
+
+@SpringBootApplication
+public class WorkplanApplication {
+
+    public static void main(String[] args) {
+        SpringApplication.run(WorkplanApplication.class, args);
+    }
+}

--- a/src/test/java/com/example/workplan/WorkplanApplicationTests.java
+++ b/src/test/java/com/example/workplan/WorkplanApplicationTests.java
@@ -1,0 +1,12 @@
+package com.example.workplan;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.boot.test.context.SpringBootTest;
+
+@SpringBootTest
+class WorkplanApplicationTests {
+
+    @Test
+    void contextLoads() {
+    }
+}


### PR DESCRIPTION
## Summary
- replace the Gradle build with a Maven configuration using Spring Boot 3.3.4 and Java 21
- update the GitHub Actions workflow and repository docs to reference Maven commands
- drop the Gradle wrapper, bootstrap script, and other Gradle-specific artifacts

## Testing
- mvn -B verify

------
https://chatgpt.com/codex/tasks/task_e_68fe2de8ebd88327ae80124fe05c561e